### PR TITLE
Add support for RSTB files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Preview and edit subfiles of SARC and BNTX archives
 - ASB (Changes automatically applied to corresponding BAEV)
 - BAEV (Changes automatically applied to corresponding ASB)
 - XLINK
+- RESTBL (`.rsizetable` resource size tables, with CRC32 hashes resolved to resource paths)
 - PCHTXT
 - TKMM Config Files
 

--- a/config/coreFsExtensions.json
+++ b/config/coreFsExtensions.json
@@ -6,5 +6,6 @@
   "asb": "asb",
   "baev": "baev",
   "belnk": "xlnk",
-  "bslnk": "xlnk"
+  "bslnk": "xlnk",
+  "rsizetable": "rstb"
 }

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -516,6 +516,7 @@ Loaded from [`config/coreFsExtensions.json`](../../config/coreFsExtensions.json)
 | `asb` | `asb` | `json` |
 | `baev` | `baev` | `json` |
 | `belnk`, `bslnk` | `xlnk` | `yaml` |
+| `rsizetable` | `rstb` | `totk-rstb` |
 
 AAMP types: large built-in list in [`config/aamp-extensions.json`](../../config/aamp-extensions.json) plus `TKVSC.extraAampExtensions` and manifest `aampExtensions`.
 

--- a/icons/rstb.svg
+++ b/icons/rstb.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="rstb" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #e08c2e;
+      }
+
+      .cls-2 {
+        fill: #f5d9b0;
+      }
+    </style>
+  </defs>
+  <rect class="cls-1" x="3" y="4" width="26" height="24" rx="4" ry="4"/>
+  <rect class="cls-2" x="6" y="8" width="9" height="3" rx="1" ry="1"/>
+  <rect class="cls-2" x="17" y="8" width="9" height="3" rx="1" ry="1"/>
+  <rect class="cls-2" x="6" y="14.5" width="9" height="3" rx="1" ry="1"/>
+  <rect class="cls-2" x="17" y="14.5" width="5" height="3" rx="1" ry="1"/>
+  <rect class="cls-2" x="6" y="21" width="9" height="3" rx="1" ry="1"/>
+  <rect class="cls-2" x="17" y="21" width="7" height="3" rx="1" ry="1"/>
+</svg>

--- a/icons/totk-icon-theme.json
+++ b/icons/totk-icon-theme.json
@@ -39,6 +39,9 @@
     },
     "_totk_font": {
       "iconPath": "./font.svg"
+    },
+    "_totk_rstb": {
+      "iconPath": "./rstb.svg"
     }
   },
   "folderNames": {
@@ -164,7 +167,9 @@
     "bfttf": "_totk_font",
     "bfotf": "_totk_font",
     "ttf": "_totk_font",
-    "otf": "_totk_font"
+    "otf": "_totk_font",
+    "rsizetable": "_totk_rstb",
+    "rsizetable.zs": "_totk_rstb"
   },
   "fileNames": {
     ".tkproj": "_totk_tkproj",
@@ -177,6 +182,7 @@
     "totk-ainb": "_totk_ainb",
     "totk-xlnk": "_totk_xlnk",
     "totk-tkvsc": "_totk_tkvsc",
-    "totk-font": "_totk_font"
+    "totk-font": "_totk_font",
+    "totk-rstb": "_totk_rstb"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "totk-vscode",
-  "version": "0.0.4-beta.1",
+  "version": "0.0.5-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "totk-vscode",
-      "version": "0.0.4-beta.1",
+      "version": "0.0.5-beta.1",
       "dependencies": {
         "opentype.js": "^2.0.0",
         "sql.js": "^1.14.1"
@@ -1443,6 +1443,7 @@
       "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.66.0",
         "@typescript-eslint/types": "8.66.0",
@@ -2249,6 +2250,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3663,6 +3665,7 @@
       "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -8216,6 +8219,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8412,6 +8416,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -258,6 +258,23 @@
         }
       },
       {
+        "id": "totk-rstb",
+        "extensions": [
+          ".rsizetable",
+          ".rsizetable.zs"
+        ],
+        "aliases": [
+          "Resource Size Table",
+          "RESTBL",
+          "rsizetable"
+        ],
+        "configuration": "./config/language-configuration.json",
+        "icon": {
+          "light": "./icons/rstb.svg",
+          "dark": "./icons/rstb.svg"
+        }
+      },
+      {
         "id": "pchtxt",
         "extensions": [
           ".pchtxt"
@@ -281,6 +298,11 @@
       },
       {
         "language": "msbt",
+        "scopeName": "source.byml",
+        "path": "./syntaxes/byml.tmLanguage.json"
+      },
+      {
+        "language": "totk-rstb",
         "scopeName": "source.byml",
         "path": "./syntaxes/byml.tmLanguage.json"
       },
@@ -923,6 +945,11 @@
           "default": "smallFilesOnly",
           "markdownDescription": "Syntax highlighting for decoded **XLNK** (`.belnk`/`.bslnk`) files. VS Code disables highlighting above 20 MB or 300,000 lines, which covers the full `elink2`/`slink2` databases. Setting this to `always` lifts that limit for XLNK files only. Takes effect the next time the file is opened."
         },
+        "TKVSC.rstbResolveHashNames": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Resolve the CRC32 hashes in **RESTBL** (`.rsizetable`) files back to readable resource paths using the game dump indexes. Turn this off to show raw `0x` hashes instead, which opens large tables faster. Requires the Game Dump Search Index (**TKVSC: Rebuild Game Dump Search Index**)."
+        },
         "TKVSC.extraAampExtensions": {
           "type": "array",
           "items": {
@@ -1082,6 +1109,10 @@
         "editor.insertSpaces": true,
         "editor.tabSize": 2,
         "editor.largeFileOptimizations": false
+      },
+      "[totk-rstb]": {
+        "editor.insertSpaces": true,
+        "editor.tabSize": 2
       }
     }
   },

--- a/python/rstb_io.py
+++ b/python/rstb_io.py
@@ -1,0 +1,367 @@
+"""Read/write Nintendo RESTBL resource size tables (``.rsizetable``).
+
+TotK ships one at ``System/Resource/ResourceSizeTable.Product.<ver>.rsizetable.zs``;
+it tells the game how much memory to reserve for every resource it loads. The
+binary layout is::
+
+    char[6] magic               "RESTBL"
+    u32     version             1
+    u32     string_block_size   bytes reserved per name-table string
+    u32     crc_table_count
+    u32     name_table_count
+    { u32 hash, u32 size }[crc_table_count]                      sorted by hash
+    { char[string_block_size] name, u32 size }[name_table_count]  sorted by name
+
+Hash entries key on the CRC32 of a resource's canonical path (the RomFS-relative
+path with the ``.zs`` extension removed), so the editor text resolves those
+hashes back to readable paths using the game-dump indexes when they exist.
+Anything that cannot be recovered stays a raw ``0x`` hash and is written back
+unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import struct
+import zlib
+
+from compression import compress_container, decompress_container
+
+MAGIC = b"RESTBL"
+HEADER_SIZE = 22
+DEFAULT_STRING_BLOCK_SIZE = 160
+DEFAULT_VERSION = 1
+
+_HASH_SECTION = "Hash"
+_NAME_SECTION = "Name"
+
+_ARCHIVE_SEPARATORS = (".pack/", ".sarc/", ".genvb/", ".blarc/", ".bfarc/", ".bntx/")
+
+
+class RstbError(ValueError):
+    """Raised for malformed RESTBL binaries or editor text."""
+
+
+def is_rstb_extension(logical_path: str) -> bool:
+    lower = logical_path.lower().replace("\\", "/")
+    if lower.endswith(".zs"):
+        lower = lower[:-3]
+    return lower.endswith(".rsizetable")
+
+
+def is_rstb_binary(file_data: bytes) -> bool:
+    if file_data[:6] == MAGIC:
+        return True
+    try:
+        data, _, _ = decompress_container(file_data, "", "")
+    except ValueError:
+        return False
+    return data[:6] == MAGIC
+
+
+class ResourceSizeTable:
+    def __init__(
+        self,
+        version: int = DEFAULT_VERSION,
+        string_block_size: int = DEFAULT_STRING_BLOCK_SIZE,
+        hash_entries: dict[int, int] | None = None,
+        name_entries: dict[str, int] | None = None,
+    ) -> None:
+        self.version = version
+        self.string_block_size = string_block_size
+        self.hash_entries: dict[int, int] = hash_entries or {}
+        self.name_entries: dict[str, int] = name_entries or {}
+
+
+def parse_rstb(data: bytes) -> ResourceSizeTable:
+    if len(data) < HEADER_SIZE:
+        raise RstbError(f"File is too small to be a RESTBL ({len(data)} bytes).")
+    if data[:6] != MAGIC:
+        raise RstbError(f"Unknown RESTBL magic: {data[:6]!r}")
+
+    version, string_block_size, crc_count, name_count = struct.unpack_from("<IIII", data, 6)
+    if string_block_size == 0:
+        raise RstbError("RESTBL header declares a zero-length string block.")
+
+    expected = HEADER_SIZE + crc_count * 8 + name_count * (string_block_size + 4)
+    if len(data) < expected:
+        raise RstbError(
+            f"RESTBL is truncated: header describes {expected} bytes, file has {len(data)}."
+        )
+
+    table = ResourceSizeTable(version, string_block_size)
+
+    offset = HEADER_SIZE
+    for hash_value, size in struct.iter_unpack("<II", data[offset : offset + crc_count * 8]):
+        table.hash_entries[hash_value] = size
+
+    offset += crc_count * 8
+    stride = string_block_size + 4
+    for index in range(name_count):
+        start = offset + index * stride
+        raw_name = data[start : start + string_block_size]
+        name = raw_name.split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+        table.name_entries[name] = struct.unpack_from("<I", data, start + string_block_size)[0]
+
+    return table
+
+
+def build_rstb(table: ResourceSizeTable) -> bytes:
+    string_block_size = table.string_block_size or DEFAULT_STRING_BLOCK_SIZE
+
+    for name in table.name_entries:
+        encoded = len(name.encode("utf-8"))
+        if encoded >= string_block_size:
+            raise RstbError(
+                f"Name entry is too long for the {string_block_size}-byte string block "
+                f"({encoded + 1} bytes needed): {name}. Raise StringBlockSize in the header "
+                "to make room."
+            )
+
+    out = bytearray()
+    out += MAGIC
+    out += struct.pack(
+        "<IIII",
+        table.version,
+        string_block_size,
+        len(table.hash_entries),
+        len(table.name_entries),
+    )
+
+    for hash_value in sorted(table.hash_entries):
+        out += struct.pack("<II", hash_value, table.hash_entries[hash_value])
+
+    for name in sorted(table.name_entries, key=lambda value: value.encode("utf-8")):
+        out += name.encode("utf-8").ljust(string_block_size, b"\x00")
+        out += struct.pack("<I", table.name_entries[name])
+
+    return bytes(out)
+
+
+def _resolve_names_enabled() -> bool:
+    return os.environ.get("TKVSC_RSTB_RESOLVE_NAMES", "1").strip() != "0"
+
+
+def _index_databases() -> list[tuple[str, str]]:
+    sources = [
+        (
+            os.environ.get("TKVSC_CANONICAL_INDEX", "").strip(),
+            "SELECT DISTINCT canonical_path FROM canonical_entries",
+        ),
+        (os.environ.get("TKVSC_ROMFS_INDEX", "").strip(), "SELECT path FROM files"),
+    ]
+    return [(path, query) for path, query in sources if path and os.path.isfile(path)]
+
+
+def _path_candidates(path: str) -> list[str]:
+    if path.endswith(".zs"):
+        path = path[:-3]
+
+    candidates = [path]
+    if path.endswith(".mc"):
+        candidates.append(path[:-3])
+
+    best = -1
+    best_length = 0
+    for separator in _ARCHIVE_SEPARATORS:
+        position = path.rfind(separator)
+        if position > best:
+            best = position
+            best_length = len(separator)
+    if best >= 0:
+        candidates.append(path[best + best_length :])
+
+    return candidates
+
+
+def resolve_hash_names(hashes: set[int]) -> dict[int, str]:
+    names: dict[int, str] = {}
+    if not hashes or not _resolve_names_enabled():
+        return names
+
+    for db_path, query in _index_databases():
+        try:
+            connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        except sqlite3.Error:
+            continue
+        try:
+            for (indexed_path,) in connection.execute(query):
+                if not indexed_path:
+                    continue
+                for candidate in _path_candidates(indexed_path):
+                    hash_value = zlib.crc32(candidate.encode("utf-8"))
+                    if hash_value in hashes and hash_value not in names:
+                        names[hash_value] = candidate
+        except sqlite3.Error:
+            continue
+        finally:
+            connection.close()
+
+        if len(names) == len(hashes):
+            break
+
+    return names
+
+
+def _quote_key(key: str) -> str:
+    return '"' + key.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _unquote_key(key: str) -> str:
+    if len(key) >= 2 and key[0] == key[-1] and key[0] in ('"', "'"):
+        inner = key[1:-1]
+        if key[0] == '"':
+            return inner.replace('\\"', '"').replace("\\\\", "\\")
+        return inner
+    return key
+
+
+def to_editor_text(table: ResourceSizeTable) -> str:
+    names = resolve_hash_names(set(table.hash_entries))
+    resolved = sorted((name, table.hash_entries[h]) for h, name in names.items())
+    unresolved = sorted(h for h in table.hash_entries if h not in names)
+
+    lines = [
+        f"# Resource Size Table (RESTBL v{table.version})",
+        "#",
+        "# Hash: entries keyed by resource path - the path's CRC32 is what gets written",
+        "#   back, so renaming a key re-points the entry. Paths that could not be",
+        f"#   recovered from the game-dump index stay as raw 0x hashes ({len(unresolved)} of",
+        f"#   {len(table.hash_entries)} here); their sizes are still editable.",
+        "# Name: entries the table stores with an explicit name, used by the game when",
+        "#   two paths collide. Names must fit in StringBlockSize bytes.",
+        "",
+        f"Version: {table.version}",
+        f"StringBlockSize: {table.string_block_size}",
+        "",
+        f"{_HASH_SECTION}:",
+    ]
+
+    lines.extend(f"  {_quote_key(name)}: {size}" for name, size in resolved)
+    if unresolved:
+        lines.append("  # Unresolved hashes")
+        lines.extend(f'  "0x{h:08x}": {table.hash_entries[h]}' for h in unresolved)
+
+    lines.append("")
+    lines.append(f"{_NAME_SECTION}:")
+    lines.extend(
+        f"  {_quote_key(name)}: {table.name_entries[name]}"
+        for name in sorted(table.name_entries, key=lambda value: value.encode("utf-8"))
+    )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _parse_size(raw: str, line_number: int, key: str) -> int:
+    text = raw.strip()
+    try:
+        size = int(text, 16) if text.lower().startswith("0x") else int(text)
+    except ValueError:
+        raise RstbError(f"Line {line_number}: size for {key} is not a number: {text}") from None
+    if size < 0 or size > 0xFFFFFFFF:
+        raise RstbError(f"Line {line_number}: size for {key} does not fit in a u32: {size}")
+    return size
+
+
+def from_editor_text(
+    editor_text: str, fallback: ResourceSizeTable | None = None
+) -> ResourceSizeTable:
+    base = fallback or ResourceSizeTable()
+    table = ResourceSizeTable(base.version, base.string_block_size)
+    hash_sources: dict[int, str] = {}
+    section: str | None = None
+
+    for line_number, raw_line in enumerate(editor_text.splitlines(), start=1):
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if not line[0].isspace():
+            head, _, tail = stripped.partition(":")
+            head = head.strip()
+            tail = tail.strip()
+            if head in (_HASH_SECTION, _NAME_SECTION) and not tail:
+                section = head
+                continue
+            if head == "Version":
+                table.version = _parse_size(tail, line_number, "Version")
+                continue
+            if head == "StringBlockSize":
+                table.string_block_size = _parse_size(tail, line_number, "StringBlockSize")
+                continue
+            raise RstbError(f"Line {line_number}: unexpected top-level entry: {stripped}")
+
+        if section is None:
+            raise RstbError(
+                f"Line {line_number}: entry outside a '{_HASH_SECTION}:' or "
+                f"'{_NAME_SECTION}:' section: {stripped}"
+            )
+
+        key_text, separator, value_text = stripped.rpartition(":")
+        if not separator:
+            raise RstbError(f"Line {line_number}: expected '<key>: <size>', got: {stripped}")
+        key = _unquote_key(key_text.strip())
+        if not key:
+            raise RstbError(f"Line {line_number}: entry has an empty key.")
+        size = _parse_size(value_text, line_number, key)
+
+        if section == _NAME_SECTION:
+            table.name_entries[key] = size
+            continue
+
+        if key.lower().startswith("0x"):
+            try:
+                hash_value = int(key, 16)
+            except ValueError:
+                raise RstbError(f"Line {line_number}: invalid hash key: {key}") from None
+            if hash_value > 0xFFFFFFFF:
+                raise RstbError(f"Line {line_number}: hash does not fit in a u32: {key}")
+        else:
+            hash_value = zlib.crc32(key.encode("utf-8"))
+
+        previous = hash_sources.get(hash_value)
+        if previous is not None and previous != key:
+            raise RstbError(
+                f"Line {line_number}: {key} and {previous} share CRC32 0x{hash_value:08x}. "
+                f"Move one of them to the '{_NAME_SECTION}:' section."
+            )
+        hash_sources[hash_value] = key
+        table.hash_entries[hash_value] = size
+
+    if table.string_block_size <= 0:
+        raise RstbError("StringBlockSize must be greater than zero.")
+
+    return table
+
+
+def read_rstb_content(file_data: bytes, logical_path: str = "", romfs_path: str = "") -> str:
+    file_data, _, _ = decompress_container(file_data, logical_path, romfs_path)
+    if len(file_data) == 0:
+        return to_editor_text(ResourceSizeTable())
+    return to_editor_text(parse_rstb(file_data))
+
+
+def write_rstb_bytes(
+    orig_file_data: bytes,
+    editor_text: str,
+    logical_path: str = "",
+    romfs_path: str = "",
+) -> bytes:
+    orig_file_data, is_zstd, is_yaz0 = decompress_container(
+        orig_file_data, logical_path, romfs_path
+    )
+    if logical_path.lower().endswith(".zs"):
+        is_zstd = True
+
+    fallback: ResourceSizeTable | None = None
+    if orig_file_data[:6] == MAGIC:
+        try:
+            fallback = parse_rstb(orig_file_data)
+        except RstbError:
+            fallback = None
+
+    table = from_editor_text(editor_text, fallback)
+    return compress_container(build_rstb(table), logical_path, romfs_path, is_zstd, is_yaz0)

--- a/python/totk_bridge.py
+++ b/python/totk_bridge.py
@@ -531,6 +531,8 @@ def _file_kind(
             return "aamp"
         if is_xlnk_binary(data):
             return "xlnk"
+        if data[:6] == b"RESTBL":
+            return "rstb"
     return None
 
 
@@ -560,10 +562,14 @@ def read_file_content(file_data: bytes, logical_path: str, sarc=None, romfs_path
         return read_baev_content_disk(logical_path, romfs_path)
     if kind == "xlnk":
         return read_xlnk_content(file_data, logical_path, romfs_path)
+    if kind == "rstb":
+        from rstb_io import read_rstb_content
+
+        return read_rstb_content(file_data, logical_path, romfs_path)
     return (
         f"<Binary Data: {len(file_data)} bytes. "
         "Editable types: .byml, .bgyml, .msbt, .ainb, .asb, .baev, .belnk, .bslnk, "
-        "AAMP (many extensions - see aamp-extensions.json)>"
+        ".rsizetable, AAMP (many extensions - see aamp-extensions.json)>"
     )
 
 
@@ -638,6 +644,14 @@ def write_file_content(
     elif kind == "xlnk":
         orig = get_original_bytes()
         new_bytes = write_xlnk_bytes(orig, editor_text, logical_path, romfs_path)
+        writer = make_sarc_writer(sarc)
+        writer.files[logical_path] = new_bytes
+        save_sarc(archive_path, writer.write()[1], is_sarc_compressed)
+    elif kind == "rstb":
+        from rstb_io import write_rstb_bytes
+
+        orig = get_original_bytes()
+        new_bytes = write_rstb_bytes(orig, editor_text, logical_path, romfs_path)
         writer = make_sarc_writer(sarc)
         writer.files[logical_path] = new_bytes
         save_sarc(archive_path, writer.write()[1], is_sarc_compressed)
@@ -718,6 +732,14 @@ def main():
             elif kind == "xlnk":
                 Path(file_path).write_bytes(
                     write_xlnk_bytes(
+                        Path(file_path).read_bytes(), editor_text, file_path, romfs_path
+                    )
+                )
+            elif kind == "rstb":
+                from rstb_io import write_rstb_bytes
+
+                Path(file_path).write_bytes(
+                    write_rstb_bytes(
                         Path(file_path).read_bytes(), editor_text, file_path, romfs_path
                     )
                 )
@@ -1169,6 +1191,15 @@ def main():
                         from aamp_io import read_aamp_content
 
                         yaml_text = read_aamp_content(file_data, internal_path, romfs_path)
+                        fd, yaml_path = tempfile.mkstemp(prefix="totk-cvt-", suffix=target_ext)
+                        os.close(fd)
+                        Path(yaml_path).write_text(yaml_text, encoding="utf-8")
+                        os.unlink(out_path)
+                        out_path = yaml_path
+                    elif kind == "rstb":
+                        from rstb_io import read_rstb_content
+
+                        yaml_text = read_rstb_content(file_data, logical_path, romfs_path)
                         fd, yaml_path = tempfile.mkstemp(prefix="totk-cvt-", suffix=target_ext)
                         os.close(fd)
                         Path(yaml_path).write_text(yaml_text, encoding="utf-8")

--- a/scripts/convert_ainb_defs.py
+++ b/scripts/convert_ainb_defs.py
@@ -100,7 +100,10 @@ def _read_params(reader: Reader, has_flags: bool) -> list:
         value_type = reader.u8()
         if has_flags:
             reader.skip(reader.u8())
-        entry = {"n": name, "t": VALUE_TYPES[value_type] if value_type < len(VALUE_TYPES) else "Int"}
+        entry = {
+            "n": name,
+            "t": VALUE_TYPES[value_type] if value_type < len(VALUE_TYPES) else "Int",
+        }
         if classname:
             entry["c"] = classname
         out.append(entry)
@@ -176,8 +179,10 @@ def main() -> int:
     out_path.write_bytes(gzip.compress(payload, 9))
 
     print(f"{len(definitions)} definitions")
-    print(f"{len(data) / 1e6:.1f} MB -> {len(payload) / 1e6:.2f} MB JSON -> "
-          f"{out_path.stat().st_size / 1e6:.2f} MB gzipped")
+    print(
+        f"{len(data) / 1e6:.1f} MB -> {len(payload) / 1e6:.2f} MB JSON -> "
+        f"{out_path.stat().st_size / 1e6:.2f} MB gzipped"
+    )
     print(f"wrote {out_path}")
     return 0
 

--- a/src/api/bridgeEnv.ts
+++ b/src/api/bridgeEnv.ts
@@ -7,6 +7,7 @@ import {
 } from '../gameProfile';
 import { getHandlerManifestPath } from '../handlerManifest';
 import { getAampHashNamesPath } from '../aampHashNames';
+import { getIndexPathsForGame } from '../indexPaths';
 
 /** Bridge environment variables passed to `totk_bridge.py`. */
 export function getBridgeEnv(): NodeJS.ProcessEnv {
@@ -18,6 +19,7 @@ export function getBridgeEnv(): NodeJS.ProcessEnv {
     const aampHashNamesPath = getAampHashNamesPath() ?? '';
     const archiveExtensions = profile.indexing?.archiveExtensions ?? [];
     const msbtConfigPath = getActiveMsbtConfigPath();
+    const indexPaths = getIndexPathsForGame(profile.id);
     return {
         ...process.env,
         TOTK_EDITOR_ROMFS: romfsPath,
@@ -27,6 +29,9 @@ export function getBridgeEnv(): NodeJS.ProcessEnv {
         TKVSC_ARCHIVE_EXTENSIONS: archiveExtensions.join(','),
         TKVSC_HANDLER_MANIFEST: manifestPath,
         TKVSC_AAMP_HASH_NAMES: aampHashNamesPath,
+        TKVSC_ROMFS_INDEX: indexPaths?.romfsIndex ?? '',
+        TKVSC_CANONICAL_INDEX: indexPaths?.canonicalIndex ?? '',
+        TKVSC_RSTB_RESOLVE_NAMES: config.get<boolean>('rstbResolveHashNames', true) ? '1' : '0',
         ...(msbtConfigPath ? { TKVSC_MSBT_CONFIG: msbtConfigPath } : {}),
         TOTK_TAG_PRODUCT_FORMAT: config.get<string>('tagProductFormat', 'json'),
         TOTK_EXTRA_AAMP_EXTS: extraAamp.map((ext) => ext.replace(/^\./, '')).join(','),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,12 @@ import {
     getGameProfileRegistry,
     isRomfsPathValid,
 } from './gameProfile';
-import { getGameIndexPaths, INDEX_SCHEMA_VERSION, migrateLegacyIndexFiles } from './indexPaths';
+import {
+    getGameIndexPaths,
+    INDEX_SCHEMA_VERSION,
+    migrateLegacyIndexFiles,
+    setIndexStorageRoot,
+} from './indexPaths';
 import {
     detectProjectAdapter,
     detectProjectAdapterAsync,
@@ -778,6 +783,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<TkvscA
     cleanupOldTempFiles();
 
     initAddonRegistries(context);
+    setIndexStorageRoot(context.globalStorageUri.fsPath);
     void migrateLegacyIndexFiles(context.globalStorageUri.fsPath);
     initTextureViewer(context.extensionUri);
     initAudioViewer(context.extensionUri);
@@ -1660,6 +1666,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<TkvscA
         '.bgyml': { 'BYML': ['bgyml'], 'YAML': ['yaml'] },
         '.txtg': { 'TexToGo Image': ['txtg'], 'DDS': ['dds'], 'PNG': ['png'], 'JPEG': ['jpg'], 'TGA': ['tga'], 'BMP': ['bmp'] },
         '.msbt': { 'Message Text': ['msbt'], 'JSON': ['json'], 'Text': ['txt'] },
+        '.rsizetable': { 'Resource Size Table': ['rsizetable'], 'YAML': ['yaml'] },
     };
 
     const getFiltersForExtension = (ext: string): Record<string, string[]> => {

--- a/src/formatRegistry.ts
+++ b/src/formatRegistry.ts
@@ -46,9 +46,10 @@ const LANGUAGE_BY_HANDLER: Record<string, string> = {
     asb: 'json',
     baev: 'json',
     xlnk: 'totk-xlnk',
+    rstb: 'totk-rstb',
 };
 
-const BUILTIN_HANDLERS = new Set(['byml', 'msbt', 'aamp', 'ainb', 'asb', 'baev', 'xlnk']);
+const BUILTIN_HANDLERS = new Set(['byml', 'msbt', 'aamp', 'ainb', 'asb', 'baev', 'xlnk', 'rstb']);
 
 function normalizeExtension(ext: string): string {
     return ext.toLowerCase().replace(/^\./, '');

--- a/src/indexPaths.ts
+++ b/src/indexPaths.ts
@@ -11,6 +11,16 @@ export interface GameIndexPaths {
     canonicalIndexState: string;
 }
 
+let indexStorageRoot: string | undefined;
+
+export function setIndexStorageRoot(globalStorageFsPath: string): void {
+    indexStorageRoot = globalStorageFsPath;
+}
+
+export function getIndexPathsForGame(gameId: string): GameIndexPaths | undefined {
+    return indexStorageRoot ? getGameIndexPaths(indexStorageRoot, gameId) : undefined;
+}
+
 export function getGameIndexDir(globalStorageFsPath: string, gameId: string): string {
     return path.join(globalStorageFsPath, 'indexes', gameId);
 }


### PR DESCRIPTION
## Summary
Adds support for the Resource Size Table using a new rstb_io file. Automatically converts hashes to names if the game index is built.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Dependency update
- [ ] Other (describe below)

## Checklist
- [x] Code builds without errors (`npm run build`)
- [x] Changes are tested locally
- [x] No unrelated files changed
